### PR TITLE
Bring site up to date

### DIFF
--- a/_includes/docs-sidebar.html
+++ b/_includes/docs-sidebar.html
@@ -7,34 +7,21 @@
     </ul>
     <ul class="nav nav-sidebar">
       <li class="nav-label">Community Resources</li>
-      <li class="active"><a href="../tutorials/">Tutorials</a></li>
-      <li{%if page.active-sub-nav == "Videos" %}  class="active"{% endif %}><a href="../videos.html">Videos</a></li>
+      <li{%if page.active-sub-nav == "Getting Started" %}  class="active"{% endif %}><a href="https://medium.com/interledger-blog">Blog &amp; Tutorials</a></li>
       <li{%if page.active-sub-nav == "Libraries" %}  class="active"{% endif %}><a href="../libraries.html">Libraries &amp; Tools</a></li>
     </ul>
     <ul class="nav nav-sidebar">
       <li class="nav-label">Specs</li>
-      <li><a href="rfcs/0001-interledger-architecture/">Interledger Architecture</a></li>
+  <!--    <li><a href="rfcs/0001-interledger-architecture/">Interledger Architecture</a></li> -->
   <!--     <li><a href="rfcs/0002-crypto-conditions/">Crypto-conditions</a></li> -->
-      <li><a href="rfcs/0003-interledger-protocol/">Interledger Protocol (ILP)</a></li>
+      <li><a href="rfcs/0027-interledger-protocol-4/">Interledger Protocol 4 (ILPv4)</a></li>
       <li><a href="rfcs/0015-ilp-addresses/">Interledger Addresses</a></li>
-      <li><a href="rfcs/0016-pre-shared-key/">Pre-Shared Key (PSK) Protocol</a></li>
-      <li><a href="rfcs/0011-interledger-payment-request/">Interledger Payment Request (IPR)</a></li>
+      <li><a href="rfcs/0025-pre-shared-key-2/">Pre-Shared Key Protocol 2 (PSK2)</a></li>
       <li><a href="rfcs/0009-simple-payment-setup-protocol/">Simple Payment Setup Protocol (SPSP)</a></li>
-      <li><a href="rfcs/0004-ledger-plugin-interface/">Javascript Ledger Plugin Interface</a></li>
+      <li><a href="rfcs/0026-payment-pointers/">Payment Pointers</a></li>
+      <li><a href="rfcs/0024-ledger-plugin-interface/">JS Ledger Plugin Interface 2 (LPI2)</a></li>
+      <li><a href="rfcs/0028-web-monetization/">Web Monetization</a></li>
       <li><a target="_blank" href="https://w3c.github.io/webpayments/proposals/interledger-payment-method.html">W3C Web Payments Interledger Payment Method</a></li>
-    </ul>
-    <ul class="nav nav-sidebar">
-      <li class="nav-label">Technical Documentation</li>
-      <li><a href="{{site.interledgerjs_baseurl}}five-bells-ledger/apidoc/">five-bells-ledger</a></li>
-      <li><a href="{{site.interledgerjs_baseurl}}ilp-connector/apidoc/">ilp-connector</a></li>
-      <li><a href="{{site.interledgerjs_baseurl}}ilp-kit/apidoc/">ilp-kit</a></li>
-      <li><a href="{{site.interledgerjs_baseurl}}five-bells-condition/jsdoc/">five-bells-condition</a></li>
-      <li><a href="{{site.interledgerjs_baseurl}}five-bells-shared/jsdoc/">five-bells-shared</a></li>
-      <li><a href="{{site.interledgerjs_baseurl}}five-bells-notary/apidoc/">five-bells-notary</a></li>
-    </ul>
-    <ul class="nav nav-sidebar">
-      <li class="nav-label">Whitepaper</li>
-      <li><a href="http://interledger.org/interledger.pdf">Download PDF</a></li>
     </ul>
   </div>
 </div>

--- a/getting-started.html
+++ b/getting-started.html
@@ -13,37 +13,19 @@ active-sub-nav: "Getting Started"
         <div class="col-sm-8 wrapper">
           <h1 class="page-header">Getting Started</h1>
 
-          <h2>Tutorials</h2>
-
-          <p class="intro">Developers, check out our <a href="/tutorials/">tutorials collection</a> to understand how Interledger works under the hood.</p>
-
           <h2>Sending Your First Interledger Payment</h2>
 
-          <p class="intro">Sign up for the demo wallets and start sending Interledger payments between them in under 3 minutes.</p>
+          <p class="intro">Follow our tutorials to start sending Interledger payments in under 3 minutes.</p>
+    
+          <p>First, follow "<a href="https://medium.com/interledger-blog/using-moneyd-to-join-the-ilp-testnet-ba64bd42bb14">Using Moneyd to Join the ILP Testnet</a>" to get connected to the Interledger testnet. The "Testnet of Testnets," as we call it, connects different blockchain testnets together. We use it to test new protocols and tools in the Interledger stack.</p>
 
-          <p>First, create an account on the <a target="_blank" href="https://red.ilpdemo.org">Red Demo Wallet</a> and the <a target="_blank" href="https://blue.ilpdemo.org">Blue Demo Wallet</a> (one for sending and the other for receiving).</p>
-
-          <div>
-          <img class="img-responsive" src="assets/demo_register.png" />
-          </div>
-
-          <p>Now you can send payments between your accounts.</p>
-
-          <div>
-          <img class="img-responsive" src="assets/demo_send.png" />
-          </div>
-
-          <p>And they arrive instantly, even though they are on different ledgers.</p>
-
-          <div>
-          <img class="img-responsive" src="assets/demo_receive.png" />
-          </div>
+          <p>Next, follow "<a href="https://medium.com/interledger-blog/spsp-simple-payment-setup-protocol-2028292e6925">SPSP: Simple Payment Setup Protocol</a>" to send your first Interledger payment.</p>
 
           <p>Congratulations, you've sent your first Interledger payment!</p>
 
           <h2>Next Steps</h2>
 
-          <p>Want to start coding with payments? Use the accounts you just created to programmatically send and receive payments with the <a target="_blank" href="https://github.com/interledgerjs/ilp">ILP Client</a>.</p>
+          Check out the rest of our <a href="https://medium.com/interledger-blog">Interledger Blog</a> for tutorials on the latest developer tools.</p>
 
       </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -143,12 +143,13 @@ favorite programming language.
                 <div class="tab-content">
                     <div id="js2" class="tab-pane active">
                     <pre><code>const plugin = require('ilp-plugin')()
-const superagent = require('superagent')
-const agent = require('superagent-ilp')(superagent, plugin)
+const fetch = require('ilp-fetch')
 
-agent
-  .get('http://localhost:8080/')
-  .pay(5000)
+fetch('http://localhost:8080/', {
+  method: 'GET',
+  maxPrice: 5000,
+  plugin
+})
   .then(response => {
     console.log('paid!')
     console.log('got response:', response.text)
@@ -157,7 +158,8 @@ agent
 
                     <div id="sh2" class="tab-pane">
                     <pre><code>$ npm install -g ilp-curl moneyd
-$ moneyd start --host ... --secret s...
+$ moneyd configure --testnet
+$ moneyd start --testnet
 $ ilp-curl -X GET localhost:8080/pay
 Hello World!</code></pre>
                     </div>

--- a/libraries.html
+++ b/libraries.html
@@ -13,16 +13,24 @@ active-sub-nav: "Libraries"
         <div class="col-sm-8 wrapper">
           <h1 class="page-header">Libraries &amp; Tools</h1>
 
-          <p class="intro">Build high- and low-level Interledger applications.</p>
+          <p class="intro">Build Interledger applications.</p>
 
-          <h2>High Level: ILP Client (SPSP)</h2>
+          <h2>SPSP</h2>
 
-          <p>Build Interledger payments into your apps with the <a target="_blank" href="https://github.com/interledgerjs/ilp#simple-payment-setup-protocol-spsp">ILP SPSP Client</a>. This library can connect to the <a target="_blank" href="https://github.com/interledgerjs/ilp-kit">ILP Kit</a>, which uses the <a href="https://github.com/interledger/rfcs/tree/master/0009-simple-payment-setup-protocol">Simple Payment Setup Protocol</a> for account discovery and automatic payment detail negotiation.
+          <p>Build Interledger payments into your apps with the <a target="_blank" href="https://github.com/interledgerjs/ilp-protocol-spsp">ILP SPSP Client</a>. This library can connect to any SPSP receiver for account discovery and payment detail negotation. For more information on how to use SPSP, read <a href="https://medium.com/interledger-blog/spsp-simple-payment-setup-protocol-2028292e6925">"SPSP: Simple Payment Setup Protocol"</a> on the Interledger Blog.
 
 
-          <h2>Low Level: ILP Client (PSK, ILQP)</h2>
+          <h2>Koa ILP</h2>
 
-          <p>Build Interledger payments into other protocols or low-level applications with the ILP Client's <a target="_blank" href="https://github.com/interledgerjs/ilp#pre-shared-key-psk-transport-protocol">PSK</a> and <a target="_blank" href="https://github.com/interledgerjs/ilp#ilqpquoteplugin-query--promisequote">ILQP</a> functions. This library gives you direct control over the Interledger parameters and allows you to determine how to handle account discovery, condition negotiation, and communication between senders and recipients.</p>
+          <p>If you use the <a href="http://koajs.com/">Koa framework</a> in Node.js, this library will allow you to monetize your API in only a few lines of code. For more information, <a href="https://github.com/interledgerjs/koa-ilp">check out our Github</a> and <a href="https://medium.com/interledger-blog/http-ilp-paid-api-calls-with-interledger-fda53643a2eb">our blog post about it.</a></p>
+
+          <h2>ILP Fetch</h2>
+
+          <p>You can use <a href="https://github.com/interledgerjs/ilp-fetch">ILP Fetch</a> as a client to HTTP-ILP. ILP Fetch follows the <a href="https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API">Fetch API</a>, but allows the client to send payments. You can use it to interact with paid APIs on Interledger.</p>
+
+          <h2>Moneyd XRP</h2>
+
+          <p><a href="https://github.com/interledgerjs/moneyd-xrp">Moneyd-XRP</a> allows you to connect to the Interledger network via XRP. It can be used on the livenet or the testnet with minimal configuration. We also have "Moneyd-ETH" and "Moneyd-Lightning" in the works.</p>
 
           <h2>More tools coming soon!</h2>
 

--- a/overview.html
+++ b/overview.html
@@ -25,11 +25,11 @@ active-sub-nav: "Overview"
 
           <h2>Protocol Specs and APIs</h2>
 
-          <p>To dive into the technical specs, see the <a target="_blank" href="https://github.com/interledger/rfcs">Interledger RFCs</a>. Also see the documentation for the components of the reference implementation. There are the <a href="{{site.interledgerjs_baseurl}}ilp-connector/apidoc/">connector</a>, the example <a href="{{site.interledgerjs_baseurl}}five-bells-ledger/apidoc/">ledger</a> and the application layer <a href="{{site.interledgerjs_baseurl}}ilp-kit/apidoc/">ILP Kit</a>.</p>
+          <p>To dive into the technical specs, see the <a target="_blank" href="https://github.com/interledger/rfcs">Interledger RFCs</a>. Also see the documentation for the components of the reference implementation.</p>
 
           <h2>Security</h2>
 
-          <p>Interledger provides secure multi-hop payments using <a href="https://adrian.hopebailie.com/the-power-of-conditional-payments-2d1ea531250a">conditional transfers</a>. For the theoretical foundations of Interledger, read the <a target="_blank" href="interledger.pdf">Whitepaper</a> (Note: the whitepaper provides a technical defense of the protocol fundamentals, not the simplest explanation. For a higher-level overview of how it works, see the <a href="rfcs/0001-interledger-architecture/">Interledger Architecture RFC</a>).</p>
+          <p>Interledger provides secure multi-hop payments using <a href="https://github.com/interledger/rfcs/blob/master/0022-hashed-timelock-agreements/0022-hashed-timelock-agreements.md">Hashed Timelock Agreements</a>. As of Interledger version 4, these conditions are not enforced by the ledger, as it would be too costly and slow. Instead, participants in the network use these hashlocks to perform accounting with their peers. This accounting is used to determine in-flight balances, which are periodically settled with on-ledger transfers or payment channel claims. For a detailed description of how this works, read <a href="https://github.com/interledger/rfcs/blob/master/0027-interledger-protocol-4/0027-interledger-protocol-4.md">the ILPv4 specification.</a></p>
 
           <p>Next: <a href="getting-started.html">Getting Started</a></p>
       </div>


### PR DESCRIPTION
- Updates the list of specs to the latest RFCs
- Removes links to videos and whitepaper which describe ILPv1
- Updates code examples to use updated ilp-fetch and moneyd
- Updates list of libraries to koa-ilp, ilp-fetch, ilp-protocol-spsp, and moneyd
- Points to latest blog and tutorials
- Update overview to ILPv4