### PR TITLE
Fixup CLI sending example

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@ fetch('http://localhost:8080/', {
                     <pre><code>$ npm install -g ilp-curl moneyd
 $ moneyd configure --testnet
 $ moneyd start --testnet
-$ ilp-curl -X GET localhost:8080/pay
+$ ilp-curl -X GET http://localhost:8080/
 Hello World!</code></pre>
                     </div>
 


### PR DESCRIPTION
1. Removed `/pay` suffix from url
2. Added `http://` prefix to url to fix `Only HTTP(S) protocols are supported` error