### PR TITLE
Add "Pre-Shared Key V2 (PSKv2)" to list of specs in sidebar

### DIFF
--- a/_includes/docs-sidebar.html
+++ b/_includes/docs-sidebar.html
@@ -17,6 +17,7 @@
       <li><a href="rfcs/0015-ilp-addresses/">Interledger Addresses</a></li>
       <li><a href="rfcs/0029-stream/">STREAM Protocol</a></li>
       <li><a href="rfcs/0009-simple-payment-setup-protocol/">Simple Payment Setup Protocol (SPSP)</a></li>
+      <li><a href="rfcs/0025-pre-shared-key-2/">Pre-Shared Key V2 (PSKv2)</a></li>
       <li><a href="rfcs/0026-payment-pointers/">Payment Pointers</a></li>
       <li><a href="rfcs/0024-ledger-plugin-interface-2/">JS Ledger Plugin Interface 2 (LPI2)</a></li>
       <li><a href="rfcs/0028-web-monetization/">Web Monetization</a></li>


### PR DESCRIPTION
Does this belong in the "Specs" list?