### PR TITLE
Replace SPSP tutorial with STREAM

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -16,10 +16,11 @@ active-sub-nav: "Getting Started"
           <h2>Sending Your First Interledger Payment</h2>
 
           <p class="intro">Follow our tutorials to start sending Interledger payments in under 3 minutes.</p>
-    
+
           <p>First, follow "<a href="https://medium.com/interledger-blog/using-moneyd-to-join-the-ilp-testnet-ba64bd42bb14">Using Moneyd to Join the ILP Testnet</a>" to get connected to the Interledger testnet. The "Testnet of Testnets," as we call it, connects different blockchain testnets together. We use it to test new protocols and tools in the Interledger stack.</p>
 
-          <p>Next, follow "<a href="https://medium.com/interledger-blog/spsp-simple-payment-setup-protocol-2028292e6925">SPSP: Simple Payment Setup Protocol</a>" to send your first Interledger payment.</p>
+          <p>Next, follow "<a href="https://medium.com/interledger-blog/streaming-money-and-data-over-ilp-fabd76fc991e">STREAMing Money and Data Over ILP
+          </a>" to send your first Interledger payment.</p>
 
           <p>Congratulations, you've sent your first Interledger payment!</p>
 


### PR DESCRIPTION
The SPSP tutorial linked in the getting started section doesn't really work. Some error happens because it still leverages PSK2. This is a problem as there needs to be a tutorial on sending payments with payment pointers, and there's no working one without going into STREAM.

For now, I think it's most appropriate to leave a working tutorial up, so I've added the more recent one on STREAM.

I'm down to help write a new tutorial, not sure what the new interface for sending payments at the payment pointers level looks like though.