### PR TITLE
Revert "test: redirect rfcs to use interledger repo assets"

### DIFF
--- a/_dactyl/dactyl-config.yml
+++ b/_dactyl/dactyl-config.yml
@@ -120,7 +120,6 @@ pages:
         html: rfcs/0027-interledger-protocol-4/index.html
         md: https://raw.githubusercontent.com/interledger/rfcs/master/0027-interledger-protocol-4/0027-interledger-protocol-4.md
         template: template-spec.html
-        template_static_path: https://github.com/interledger/interledger.github.io/tree/master/assets
         targets:
             - en   
 


### PR DESCRIPTION
Reverts interledger/interledger.github.io#120