### PR TITLE
Changed to a New Link Which Exists

### DIFF
--- a/setup-wallets.html
+++ b/setup-wallets.html
@@ -113,7 +113,7 @@
 <li>With a <a class="external-link" href="https://rafiki.money" target="_blank">rafiki.money <i aria-hidden="true" class="fa fa-external-link"></i></a> account</li>
 </ul>
 <p>Both of these types of Interledger accounts allow you to send and receive test funds, and are useful for developing and testing apps. These types of accounts can also be referred to as "wallet" accounts.</p>
-<p>You can also interact with these wallets programmatically. See <a href="https://interledger.org/setup-wallets-programmatically.html">Use Interledger programmaticallly</a>.</p>
+<p>You can also interact with these wallets programmatically. See <a href="setup-wallets-programmatically.html">Use Interledger programmaticallly</a>.</p>
 <p>If you want to send <em>actual</em> value in your app with an Interledger account, refer to the following open-source projects (contributions welcome):</p>
 <ul>
 <li><a class="external-link" href="https://connector.interledger4j.dev" target="_blank">Java Connector <i aria-hidden="true" class="fa fa-external-link"></i></a>  — Actively maintained by Xpring and recommended for new production deployments.</li>

--- a/setup-wallets.html
+++ b/setup-wallets.html
@@ -113,7 +113,7 @@
 <li>With a <a class="external-link" href="https://rafiki.money" target="_blank">rafiki.money <i aria-hidden="true" class="fa fa-external-link"></i></a> account</li>
 </ul>
 <p>Both of these types of Interledger accounts allow you to send and receive test funds, and are useful for developing and testing apps. These types of accounts can also be referred to as "wallet" accounts.</p>
-<p>You can also interact with these wallets programmatically. See <a href="use-interledger-programmatically.html">Use Interledger programmaticallly</a>.</p>
+<p>You can also interact with these wallets programmatically. See <a href="https://interledger.org/setup-wallets-programmatically.html">Use Interledger programmaticallly</a>.</p>
 <p>If you want to send <em>actual</em> value in your app with an Interledger account, refer to the following open-source projects (contributions welcome):</p>
 <ul>
 <li><a class="external-link" href="https://connector.interledger4j.dev" target="_blank">Java Connector <i aria-hidden="true" class="fa fa-external-link"></i></a>  — Actively maintained by Xpring and recommended for new production deployments.</li>


### PR DESCRIPTION
The old link (https://interledger.org/use-interledger-programmatically.html) did not exist, rather I put in the new link which is correct: 
https://interledger.org/setup-wallets-programmatically.html